### PR TITLE
Improve case class filter

### DIFF
--- a/konira/runner.py
+++ b/konira/runner.py
@@ -1,6 +1,7 @@
 import re
 import inspect
 import sys
+import types
 from decimal          import Decimal
 from konira.exc       import KoniraFirstFail, KoniraNoSkip
 from konira.util      import StopWatch, get_class_name, get_let_attrs, set_let_attrs
@@ -230,11 +231,12 @@ def get_methods(suite, method_name):
     return methods
 
 
-
 def _collect_classes(path):
     global_modules = map(globals_from_file, [path])
-    return [i for i in global_modules[0].values() if callable(i) and i.__name__.startswith('Case_')]
-
+    has_case_class_name = lambda s: s.__name__.startswith('Case_')
+    is_a_class = lambda s: isinstance(s, (types.ClassType, types.TypeType))
+    is_a_case_class = lambda s: is_a_class(s) and has_case_class_name(s)
+    return filter(is_a_case_class, global_modules[0].values())
 
 
 def _collect_methods(module):


### PR DESCRIPTION
There's a problem with case class harvester: https://github.com/alfredodeza/konira/blob/master/konira/runner.py#L234-L236

When you have a global var that has no `__name__` attribute in your spec:

``` python
from functools import partial
foo = partial(dict, yay=1)

describe "feature": 
    it "does something cool":
        print "yay!"
```

It will choke on bootstrap: 

```
$ find . -name "*.pyc" -exec rm -f {} \;
$ konira -x -t -s tests/case_foo.py

Errors:
-------

1 ==> AttributeError: 'functools.partial' object has no attribute '__name__'
File: /Users/dada/.virtualenvs/dada/lib/python2.7/site-packages/konira/runner.py:236:
Traceback (most recent call last):
  File "/Users/dada/.virtualenvs/dada/lib/python2.7/site-packages/konira/runner.py", line 236, in _collect_classes
    return [i for i in global_modules[0].values() if callable(i) and i.__name__.startswith('Case_')]
AttributeError: 'functools.partial' object has no attribute '__name__'

```

This patch will fix it :) 
